### PR TITLE
Fixed userids being sent out for password reset having wrong bit tag. Wa...

### DIFF
--- a/evewspace/account/templates/password_reset_email.html
+++ b/evewspace/account/templates/password_reset_email.html
@@ -1,3 +1,3 @@
 {% load url from future %}
 Password reset link for {{ user }}
-{{ protocol}}://{{ domain }}{% url 'password_reset_confirm' uidb36=uid token=token %}
+{{ protocol}}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}

--- a/evewspace/account/urls.py
+++ b/evewspace/account/urls.py
@@ -61,7 +61,7 @@ urlpatterns = patterns('',
          'subject_template_name': 'reset_subject.txt'}, name='password_reset'),
     url(r'^password/reset/done$', 'django.contrib.auth.views.password_reset_done',
         {'template_name': 'password_reset_done.html'}, name='password_reset_done'),
-    url(r'^password/reset/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)',
+    url(r'^password/reset/(?P<uidb64>[0-9A-Za-z]+)-(?P<token>.+)',
         'account.views.password_reset_confirm',
         name='password_reset_confirm'),
 )


### PR DESCRIPTION
Per Django changelog documentation for 1.6 [here](https://docs.djangoproject.com/en/1.6/releases/1.6/#django-contrib-auth-password-reset-uses-base-64-encoding-of-user-pk).