### PR TITLE
Zen mode to follow global slice char setting

### DIFF
--- a/evewspace/Map/static/js/map_functions.js
+++ b/evewspace/Map/static/js/map_functions.js
@@ -1028,7 +1028,7 @@ function DrawSystem(system) {
     var friendly = "";
     if (system.Friendly) {
         if (system.Friendly.length > 6) {
-            if ((sliceLastChars == true) || (zenMode)) {
+            if (sliceLastChars == true) {
                 system.Friendly = "." + system.Friendly.slice(-6);
             } else {
                 system.Friendly = system.Friendly.slice(0, 6) + ".";


### PR DESCRIPTION
In our corp we have the most useful info at the front of the friendly name, therefore it is not handy to cut everything except the last 6 chars by default in Zen mode. I can also not think of a reason why the global setting would not suffice. Thus I´m suggesting to change it to follow the global sliceLastChars setting, just like the normal map. 

Change is (once again) not tested, but it should work.