### PR TITLE
Compact Pilot List

### DIFF
--- a/evewspace/Map/static/css/map-slate.css
+++ b/evewspace/Map/static/css/map-slate.css
@@ -3,10 +3,6 @@
     background-color: #000000;
     color: #c8c8c8;
 }
-.well
-{
-    margin-left: 20px;
-}
 #id_sigtype
 {
     color: #000000;

--- a/evewspace/Map/static/css/map.css
+++ b/evewspace/Map/static/css/map.css
@@ -146,10 +146,6 @@
 {
     text-align: center;
 }
-.activePlayerPanel
-{
-    margin-left: 46px;
-}
 .sysLSdiv
 {
     text-align: center;
@@ -249,7 +245,7 @@ textarea
 
 #scrollmenu {
     position: fixed;
-    left: 2;
+    left: 2px;
     top: 40%;
     width: 24px;
     margin: 0px;
@@ -291,4 +287,23 @@ label[for=massStatusCritical], label[for=sysTypeDangerous] {
 }
 #legendDiv ul.inline {
     display: inline;
+}
+
+div.activePlayerList {
+    text-align: center;
+}
+table.activePilotsTable {
+    border: 1px solid black;
+    margin: auto;
+}
+table.activePilotsTable tr:nth-child(2n) {
+    background-color: rgba(255, 255, 255, 0.04);
+}
+table.activePilotsTable td,
+table.activePilotsTable th {
+    padding: 0.1em 0.5em;
+}
+table.activePilotsTable td {
+    border-top: 1px solid black;
+    text-align: left;
 }

--- a/evewspace/Map/templates/system_details.html
+++ b/evewspace/Map/templates/system_details.html
@@ -148,7 +148,7 @@
     </div>
     <div id="activePlayerPanel" class="activePlayerPanel tab-pane">
         <div id="activePlayerList" class="activePlayerList">
-            <h4 style="margin-left: 120px;">Active Pilots: {{system.name}}</h4>
+            <h4>Active Pilots: {{system.name}}</h4>
             <table class="activePilotsTable" cellpadding="10">
                 <tr>
                     <th>Member</th>

--- a/evewspace/Map/templates/system_details.html
+++ b/evewspace/Map/templates/system_details.html
@@ -149,7 +149,7 @@
     <div id="activePlayerPanel" class="activePlayerPanel tab-pane">
         <div id="activePlayerList" class="activePlayerList">
             <h4>Active Pilots: {{system.name}}</h4>
-            <table class="activePilotsTable" cellpadding="10">
+            <table class="activePilotsTable">
                 <tr>
                     <th>Member</th>
                     <th>Character</th>

--- a/evewspace/Map/templates/system_details_combined.html
+++ b/evewspace/Map/templates/system_details_combined.html
@@ -153,8 +153,8 @@
     <hr class="sysInfoCombinedHr">
     <div id="activePlayerPanel" class="activePlayerPanel tab-pane">
         <div id="activePlayerList" class="activePlayerList">
-            <h4 style="margin-left: 120px;">Active Pilots: {{system.name}}</h4>
-            <table class="activePilotsTable" cellpadding="10">
+            <h4>Active Pilots: {{system.name}}</h4>
+            <table class="activePilotsTable">
                 <tr>
                     <th>Member</th>
                     <th>Character</th>


### PR DESCRIPTION
More compact UI. This particular change makes the pilot list tab in the system details much more compact. Also removed a 20px margin-left for the system details and moved the scrollmenu to 2px from the left border for all browsers.

Screenshot of the new pilot list style:
![2015-03-22_19-43-55](https://cloud.githubusercontent.com/assets/4669347/6770849/bd7c762a-d0cd-11e4-9093-2d4d2fe0c28a.png)
