### PR TITLE
Map UI tweaks

### DIFF
--- a/evewspace/Map/static/css/map-slate.css
+++ b/evewspace/Map/static/css/map-slate.css
@@ -3,10 +3,6 @@
     background-color: #000000;
     color: #c8c8c8;
 }
-.well
-{
-    margin-left: 20px;
-}
 #id_sigtype
 {
     color: #000000;

--- a/evewspace/Map/static/css/map.css
+++ b/evewspace/Map/static/css/map.css
@@ -146,10 +146,6 @@
 {
     text-align: center;
 }
-.activePlayerPanel
-{
-    margin-left: 46px;
-}
 .sysLSdiv
 {
     text-align: center;
@@ -249,7 +245,7 @@ textarea
 
 #scrollmenu {
     position: fixed;
-    left: 2;
+    left: 2px;
     top: 40%;
     width: 24px;
     margin: 0px;
@@ -291,4 +287,23 @@ label[for=massStatusCritical], label[for=sysTypeDangerous] {
 }
 #legendDiv ul.inline {
     display: inline;
+}
+
+div.activePlayerList {
+    text-align: center;
+}
+table.activePilotsTable {
+    border: 1px solid black;
+    margin: auto;
+}
+table.activePilotsTable tr:nth-child(2n) {
+    background-color: rgba(255, 255, 255, 0.04);
+}
+table.activePilotsTable td,
+table.activePilotsTable th {
+    padding: 0.1em 0.5em;
+}
+table.activePilotsTable td {
+    border-top: 1px solid black;
+    text-align: left;
 }

--- a/evewspace/Map/static/css/map.css
+++ b/evewspace/Map/static/css/map.css
@@ -285,6 +285,9 @@ label[for=massStatusCritical], label[for=sysTypeDangerous] {
     font-weight: bold;
     color: #ff0000;
 }
+#legendDiv {
+    margin-left: 24px;
+}
 #legendDiv ul.inline {
     display: inline;
 }

--- a/evewspace/Map/static/css/map.css
+++ b/evewspace/Map/static/css/map.css
@@ -307,3 +307,16 @@ table.activePilotsTable td {
     border-top: 1px solid black;
     text-align: left;
 }
+
+fieldset.addSystemWormholeType {
+    text-align: center;
+}
+fieldset.addSystemWormholeType label.checkbox {
+    display: inline-block;
+    padding-left: 0;
+}
+fieldset.addSystemWormholeType label.checkbox input[type="checkbox"] {
+    float: none;
+    margin: 0.8em 0.2em;
+}
+

--- a/evewspace/Map/templates/add_system_box.html
+++ b/evewspace/Map/templates/add_system_box.html
@@ -49,7 +49,7 @@
                         <div class="span1"><h5><-------></h5></div>
                         <div class="span2">
                             <h5>Other Side</h5>
-                            <fieldset>
+                            <fieldset class="addSystemWormholeType">
                                 <label for="bottomTypeInput">Type:</label>
                                 <input type="text" class="sysAddInput wormholeAuto input-mini" id="bottomTypeInput" name="bottomType" value="K162" onclick="this.value = '';" />
                                 <label class="checkbox" for="bottomBubbledCheckbox">

--- a/evewspace/Map/templates/add_system_box.html
+++ b/evewspace/Map/templates/add_system_box.html
@@ -3,80 +3,78 @@
         <h4>Add System Connected To: {{topMs.system.name}}</h4>
     </div>
     <div class="modal-body">
-    <form id="sysAddForm" class="form-horizontal" action="system/new/" method="post">
-        {% csrf_token %}
-        <input type="hidden" class="sysAddInput" name="topMsID" value="{{topMs.pk}}">
-        <div class="control-group">
-            <label class="control-label" for="sysNameBox">System:</label>
-            <div class="controls">
-                <input type="text" class="sysAddInput systemAuto" name="bottomSystem" id="sysNameBox" value ="{{newsystem}}" />
+        <form id="sysAddForm" class="form-horizontal" action="system/new/" method="post">
+            {% csrf_token %}
+            <input type="hidden" class="sysAddInput" name="topMsID" value="{{topMs.pk}}">
+            <div class="control-group">
+                <label class="control-label" for="sysNameBox">System:</label>
+                <div class="controls">
+                    <input type="text" class="sysAddInput systemAuto" name="bottomSystem" id="sysNameBox" value ="{{newsystem}}" />
+                </div>
             </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label" for="friendlyNameBox">Friendly Name <br /> (Max 8 Char.):</label>
-            <div class="controls">
-                <input type="text" class="sysAddInput" name="friendlyName" id="friendlyNameBox" value="">
+            <div class="control-group">
+                <label class="control-label" for="friendlyNameBox">Friendly Name <br /> (Max 8 Char.):</label>
+                <div class="controls">
+                    <input type="text" class="sysAddInput" name="friendlyName" id="friendlyNameBox" value="">
+                </div>
             </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label" for="timeStatusAnchor">Time Status:</label>
-            <div class="controls">
-                <label for="timeStatusNormal"><input type="radio" id="timeStatusAnchor" class="sysAddInput" name="timeStatus" value="0" checked="checked"> Normal &nbsp</label>
-                <label for="timeStatusEol"><input type="radio" class="sysAddInput" name="timeStatus" value="1"> End of Life</label>
+            <div class="control-group">
+                <label class="control-label" for="timeStatusAnchor">Time Status:</label>
+                <div class="controls">
+                    <label for="timeStatusNormal"><input type="radio" id="timeStatusAnchor" class="sysAddInput" name="timeStatus" value="0" checked="checked"> Normal &nbsp</label>
+                    <label for="timeStatusEol"><input type="radio" class="sysAddInput" name="timeStatus" value="1"> End of Life</label>
+                </div>
             </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label" for="massStatusAnchor">Mass Status:</label>
-            <div class="controls">
-                <label for="massStatusNormal"><input type="radio" id="massStatusAnchor" class="sysAddInput" name="massStatus" value="0" checked="checked"> Normal &nbsp</label>
-                <label for="massStatusReduced"><input type="radio" class="sysAddInput" name="massStatus" value="1"> First Shrink &nbsp</label>
-                <label for="massStatusCritical"><input type="radio" class="sysAddInput" name="massStatus" value="2"> Critical</label><br />
-            </div>
-            <br />
-            <div>
-                <h5>Wormhole Information</h5>
-                <div class="row span6">
-                    <div class="span2"> 
-                        <h5>{{topMs.system.name}} ({{topMs.friendlyname}})</h5>
-                        <fieldset style="margin-left: 25px;">
+            <div class="control-group">
+                <label class="control-label" for="massStatusAnchor">Mass Status:</label>
+                <div class="controls">
+                    <label for="massStatusNormal"><input type="radio" id="massStatusAnchor" class="sysAddInput" name="massStatus" value="0" checked="checked"> Normal &nbsp</label>
+                    <label for="massStatusReduced"><input type="radio" class="sysAddInput" name="massStatus" value="1"> First Shrink &nbsp</label>
+                    <label for="massStatusCritical"><input type="radio" class="sysAddInput" name="massStatus" value="2"> Critical</label><br />
+                </div>
+                <br />
+                <div>
+                    <h5>Wormhole Information</h5>
+                    <div class="row span6">
+                        <div class="span2"> 
+                            <h5>{{topMs.system.name}} ({{topMs.friendlyname}})</h5>
+                            <fieldset class="addSystemWormholeType">
                                 <label for="topTypeInput">Type:</label>
                                 <input type="text" class="sysAddInput wormholeAuto input-mini" id="topTypeInput" name="topType" value="K162" onclick="this.value = '';" />
-                                <label style="margin-top: 5px;" class="checkbox" for="topBubbledCheckbox">
+                                <label class="checkbox" for="topBubbledCheckbox">
                                     <input type="checkbox" class="sysAddInput" name="topBubbled" id="topBubbledCheckbox">Bubbled
                                 </label>
-                        </fieldset>
+                            </fieldset>
+                        </div>
+                        <div class="span1"><h5><-------></h5></div>
+                        <div class="span2">
+                            <h5>Other Side</h5>
+                            <fieldset>
+                                <label for="bottomTypeInput">Type:</label>
+                                <input type="text" class="sysAddInput wormholeAuto input-mini" id="bottomTypeInput" name="bottomType" value="K162" onclick="this.value = '';" />
+                                <label class="checkbox" for="bottomBubbledCheckbox">
+                                    <input type="checkbox" id="bottomBubbledCheckbox" class="sysAddInput" name="bottomBubbled">Bubbled
+                                </label>
+                            </fieldset>
+                        </div>
                     </div>
-                    <div class="span1">
-                        <h5><-------></h5>
-                    </div>
-            <div class="span2">
-                <h5>Other Side</h5>
-                <fieldset style="margin-left: 35px;">
-                    <label for="bottomTypeInput">Type:</label>
-                    <input type="text" class="sysAddInput wormholeAuto input-mini" id="bottomTypeInput" name="bottomType" value="K162" onclick="this.value = '';" />
-                    <label style="margin-top: 5px;" class="checkbox" for="bottomBubbledCheckbox">
-                        <input type="checkbox" id="bottomBubbledCheckbox" class="sysAddInput" name="bottomBubbled">Bubbled
-                    </label>
-                </fieldset>
-            </div>
-    </div>
-        </div>
+                </div>
 
-            <input type="submit" style="display: none;">
-        </form>
+                <input type="submit" style="display: none;">
+            </form>
+        </div>
     </div>
-</div>
     <div class="modal-footer">
         <a href="#" id="sysCloseButton" class="btn" data-dismiss="modal">Close</a>
-            <a href="#" id="sysAddSubmit" onclick="$('#sysAddForm').submit();" class="btn btn-primary">Add System</a>
+        <a href="#" id="sysAddSubmit" onclick="$('#sysAddForm').submit();" class="btn btn-primary">Add System</a>
     </div>
-        <script type="text/javascript">
-           $('#sysAddForm').submit(function(e){
-                        e.preventDefault();
-                        AddSystem();
-                        $('#modalHolder').modal('hide');
-                        return false;
-            });
-        </script>
-    </div>
+    <script type="text/javascript">
+        $('#sysAddForm').submit(function(e){
+            e.preventDefault();
+            AddSystem();
+            $('#modalHolder').modal('hide');
+            return false;
+        });
+    </script>
+</div>
 

--- a/evewspace/Map/templates/system_details.html
+++ b/evewspace/Map/templates/system_details.html
@@ -148,8 +148,8 @@
     </div>
     <div id="activePlayerPanel" class="activePlayerPanel tab-pane">
         <div id="activePlayerList" class="activePlayerList">
-            <h4 style="margin-left: 120px;">Active Pilots: {{system.name}}</h4>
-            <table class="activePilotsTable" cellpadding="10">
+            <h4>Active Pilots: {{system.name}}</h4>
+            <table class="activePilotsTable">
                 <tr>
                     <th>Member</th>
                     <th>Character</th>

--- a/evewspace/Map/templates/system_details_combined.html
+++ b/evewspace/Map/templates/system_details_combined.html
@@ -153,8 +153,8 @@
     <hr class="sysInfoCombinedHr">
     <div id="activePlayerPanel" class="activePlayerPanel tab-pane">
         <div id="activePlayerList" class="activePlayerList">
-            <h4 style="margin-left: 120px;">Active Pilots: {{system.name}}</h4>
-            <table class="activePilotsTable" cellpadding="10">
+            <h4>Active Pilots: {{system.name}}</h4>
+            <table class="activePilotsTable">
                 <tr>
                     <th>Member</th>
                     <th>Character</th>


### PR DESCRIPTION
More compact UI. This particular change makes the pilot list tab in the system details much more compact. Also removed a 20px margin-left for the system details and moved the scrollmenu to 2px from the left border for all browsers.

Screenshot of the new pilot list style:
![2015-03-22_19-43-55](https://cloud.githubusercontent.com/assets/4669347/6770849/bd7c762a-d0cd-11e4-9093-2d4d2fe0c28a.png)
