### PR TITLE
Fix system outlines in Firefox 37

### DIFF
--- a/evewspace/Map/static/js/map_functions.js
+++ b/evewspace/Map/static/js/map_functions.js
@@ -1231,7 +1231,7 @@ function ColorSystem(system, ellipseSystem, textSysName, textPilot) {
     var sysColor = "#f00";
     var sysStroke = "#fff";
     var sysStrokeWidth = s(2);
-    var sysStrokeDashArray = "none";
+    var sysStrokeDashArray = "1.0";
     var textColor = "#000";
     if (system.interest == true) {
         sysStrokeWidth = s(7);


### PR DESCRIPTION
Fixes https://github.com/marbindrakon/eve-wspace/issues/157

Tested in Chrome 42, Firefox 37, Internet Explorer 11

![2015-04-19_03-47-33](https://cloud.githubusercontent.com/assets/4669347/7217829/5f5b8876-e647-11e4-8875-3c43541ebb2f.png)
