### PR TITLE
Improved logging for Signatures and POSes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ local_settings.py
 .DS_Store
 doc/build/*
 .idea
+
+*.sublime-project
+
+*.sublime-workspace

--- a/evewspace/Map/default_settings.py
+++ b/evewspace/Map/default_settings.py
@@ -20,6 +20,7 @@ defaults = [
     ("MAP_SCAN_WARNING", "3"),
     ("MAP_INTEREST_TIME", "15"),
     ("MAP_ESCALATION_BURN", "3"),
+    ("MAP_ADVANCED_LOGGING", "1"),
     ("MAP_ZEN_MODE", "0"),
     ("MAP_PILOT_LIST", "0"),
     ("MAP_DETAILS_COMBINED", "0"),
@@ -34,6 +35,9 @@ defaults = [
 
 
 def load_defaults():
+    '''
+    Loads default configuration settings.
+    '''
     for setting in defaults:
         config = ConfigEntry.objects.get_or_create(name=setting[0],
                                                    user=None)[0]

--- a/evewspace/Map/models.py
+++ b/evewspace/Map/models.py
@@ -24,6 +24,7 @@ import time
 import yaml
 from Map import utils
 from Map.utils import MapJSONGenerator
+from core.utils import get_config
 from django.core.cache import cache
 # Create your models here.
 
@@ -789,7 +790,7 @@ class Signature(models.Model):
         updated = None
         action = "None"
 
-        if wascreated is True:
+        if wascreated:
             # new sig
             updated = False
             action = "Created"
@@ -839,11 +840,20 @@ class Signature(models.Model):
     def log_sig(self, user, action, map_system):
         """Log the fact that the signature was scanned."""
         
-        map_system.map.add_log(
-            user, 
-            "%s signature %s in %s (%s), %s jumps out from root system."
-            %(action, self.sigid, map_system.system.name, 
-              map_system.friendlyname, map_system.distance_from_root()))
+        # only include advanced logging if enabled
+        include_distance = get_config("MAP_ADVANCED_LOGGING", None).value
+        if include_distance == "1":
+            map_system.map.add_log(
+                user, 
+                "%s signature %s in %s (%s), %s jumps out from root system."
+                %(action, self.sigid, map_system.system.name, 
+                  map_system.friendlyname, map_system.distance_from_root()))
+        else:
+            map_system.map.add_log(
+                user, 
+                "%s signature %s in %s (%s)."
+                %(action, self.sigid, map_system.system.name, 
+                  map_system.friendlyname))
 
     def toggle_ownership(self, user):
         """Toggles ownership."""

--- a/evewspace/Map/static/js/map_functions.js
+++ b/evewspace/Map/static/js/map_functions.js
@@ -221,7 +221,7 @@ function DisplaySystemDetails(msID, sysID) {
                     $('#sysInfoDiv').focus();
                 }
             });
-            GetPOSList(sysID);
+            GetPOSList(msID);
             GetDestinations(msID);
             $('#btnImport').off();
             $('#btnImport').click(function(e){
@@ -233,13 +233,13 @@ function DisplaySystemDetails(msID, sysID) {
     });
 }
 
-function GetPOSList(sysID) {
-    var address = "/pos/" + sysID + "/";
+function GetPOSList(msID) {
+    var address = "/pos/" + msID + "/";
     $.ajax({
         type: "GET",
         url: address,
         success: function (data) {
-            var POSlist = $('#sys' + sysID + "POSDiv");
+            var POSlist = $('#sys' + msID + "POSDiv");
             POSlist.empty();
             POSlist.html(data);
         }
@@ -407,8 +407,8 @@ function GetSystemTooltips() {
     });
 }
 
-function GetAddPOSDialog(sysID) {
-    var address = "/pos/" + sysID + "/add/";
+function GetAddPOSDialog(msID) {
+    var address = "/pos/" + msID + "/add/";
     $.ajax({
         url: address,
         type: "GET",
@@ -435,9 +435,9 @@ function GetSiteSpawns(msID, sigID) {
     });
 }
 
-function AddPOS(sysID) {
+function AddPOS(msID) {
     //This function adds a system using the information in a form named #sysAddForm
-    var address = "/pos/" + sysID + "/add/";
+    var address = "/pos/" + msID + "/add/";
     var btnAddPOS = $('#btnAddPOS');
     var pos_message = $('#pos_message');
     pos_message.hide();
@@ -448,7 +448,7 @@ function AddPOS(sysID) {
         url: address,
         data: $('#addPOSForm').serialize(),
         success: function (data) {
-            GetPOSList(sysID);
+            GetPOSList(msID);
             $('#modalHolder').modal('hide');
             btnAddPOS.html('Add POS');
             btnAddPOS.removeClass('disabled');
@@ -462,19 +462,19 @@ function AddPOS(sysID) {
     });
 }
 
-function DeletePOS(posID, sysID) {
-    var address = "/pos/" + sysID + "/" + posID + "/remove/";
+function DeletePOS(posID, msID) {
+    var address = "/pos/" + msID + "/" + posID + "/remove/";
     $.ajax({
         type: "POST",
         url: address,
         success: function () {
-            GetPOSList(sysID);
+            GetPOSList(msID);
         }
     });
 }
 
-function GetEditPOSDialog(posID, sysID) {
-    var address = "/pos/" + sysID + "/" + posID + "/edit/";
+function GetEditPOSDialog(posID, msID) {
+    var address = "/pos/" + msID + "/" + posID + "/edit/";
     $.ajax({
         url: address,
         type: "GET",
@@ -487,8 +487,8 @@ function GetEditPOSDialog(posID, sysID) {
     });
 }
 
-function EditPOS(posID, sysID) {
-    var address = "/pos/" + sysID + "/" + posID + "/edit/";
+function EditPOS(posID, msID) {
+    var address = "/pos/" + msID + "/" + posID + "/edit/";
     var btnEditPOS = $('#btnAddPOS');
     $('#pos_message').hide();
     btnEditPOS.html('Saving...');
@@ -498,7 +498,7 @@ function EditPOS(posID, sysID) {
         url: address,
         data: $('#editPOSForm').serialize(),
         success: function (data) {
-            GetPOSList(sysID);
+            GetPOSList(msID);
             $('#modalHolder').modal('hide');
             btnEditPOS.html('Save POS');
             btnEditPOS.removeClass('disabled');

--- a/evewspace/Map/templates/general_settings.html
+++ b/evewspace/Map/templates/general_settings.html
@@ -20,6 +20,13 @@
             <td>Downtimes before Burning Escalation:</td>
             <td> <input type="text" class="input-mini" name="escdowntimes" value="{{escdowntimes}}"></td>
         </tr>
+        <tr>
+            <td>Advanced Logging:</td>
+            <td> 
+                <input id='advlogging' type='radio' name='advlogging' value='1' {% if advlogging == '1' %}checked='checked'{% endif %} /> On &nbsp;
+                <input type='radio' name='advlogging' value='0' {% if advlogging == '0' %}checked='checked'{% endif %} /> Off
+            </td>
+        </tr>
     </table>
     <br />
     <input type="submit" class="btn btn-primary" value="Save Changes">

--- a/evewspace/Map/templates/system_details.html
+++ b/evewspace/Map/templates/system_details.html
@@ -171,10 +171,10 @@
     <div id="systemPosPanel" class="systemPosPanel tab-pane">
         <div style="text-align: center; margin-bottom: 10px;">
             <h4>Starbases: {{system.name}}</h4>
-            {% if can_edit %}<button class="btn" onclick="GetAddPOSDialog({{mapsys.system.pk}});"><img height=32 width=32 title="Add POS" src='{{STATIC_URL}}images/plus.png'/>Add POS</button>{% endif %}
+            {% if can_edit %}<button class="btn" onclick="GetAddPOSDialog({{mapsys.pk}});"><img height=32 width=32 title="Add POS" src='{{STATIC_URL}}images/plus.png'/>Add POS</button>{% endif %}
         </div>
         <div id="systemPosWell" class="systemPosWell">
-            <div id="sys{{system.pk}}POSDiv">
+            <div id="sys{{mapsys.pk}}POSDiv">
             </div>
         </div>
     </div>

--- a/evewspace/Map/views.py
+++ b/evewspace/Map/views.py
@@ -561,7 +561,9 @@ def bulk_sig_import(request, map_id, ms_id):
                     sigid=sig_id, system=map_system.system)
 
                 # Update sig with copied TSV data
-                sig, update_type = sig.update_from_tsv(request.user, sigcreated, row, map_system)
+                sig, update_type = sig.update_from_tsv(request.user, 
+                                                       sigcreated, 
+                                                       row, map_system)
                 
                 sig.modified_by = request.user
                 sig.save()
@@ -998,17 +1000,20 @@ def general_settings(request):
     scan_threshold = get_config("MAP_SCAN_WARNING", None)
     interest_time = get_config("MAP_INTEREST_TIME", None)
     escalation_burn = get_config("MAP_ESCALATION_BURN", None)
+    advanced_logging = get_config("MAP_ADVANCED_LOGGING", None)
     if request.method == "POST":
         scan_threshold.value = int(request.POST['scanwarn'])
         interest_time.value = int(request.POST['interesttimeout'])
         pvp_threshold.value = int(request.POST['pvpthreshold'])
         npc_threshold.value = int(request.POST['npcthreshold'])
         escalation_burn.value = int(request.POST['escdowntimes'])
+        advanced_logging.value = int(request.POST['advlogging'])
         scan_threshold.save()
         interest_time.save()
         pvp_threshold.save()
         npc_threshold.save()
         escalation_burn.save()
+        advanced_logging.save()
         return HttpResponse()
     return TemplateResponse(
         request, 'general_settings.html',
@@ -1016,7 +1021,8 @@ def general_settings(request):
          'pvpthreshold': pvp_threshold.value,
          'scanwarn': scan_threshold.value,
          'interesttimeout': interest_time.value,
-         'escdowntimes': escalation_burn.value}
+         'escdowntimes': escalation_burn.value,
+         'advlogging': advanced_logging.value}
     )
 
 

--- a/evewspace/Map/views.py
+++ b/evewspace/Map/views.py
@@ -523,111 +523,6 @@ def set_interest(request, map_id, ms_id):
         raise PermissionDenied
 
 
-def _translate_client_string(client_text):
-    TRANSLATE_DICT = {
-        'Cosmic Signature': 'Cosmic Signature',
-        'Cosmic Anomaly': 'Cosmic Anomaly',
-        'Ore Site': 'Ore Site',
-        'Gas Site': 'Gas Site',
-        'Data Site': 'Data Site',
-        'Relic Site': 'Relic Site',
-        'Wormhole': 'Wormhole',
-        'Combat Site': 'Combat Site',
-        # Russian
-        '\xd0\x98\xd1\x81\xd1\x82\xd0\xbe\xd1\x87\xd0\xbd\xd0\xb8\xd0\xba\xd0'
-        '\xb8 \xd1\x81\xd0\xb8\xd0\xb3\xd0\xbd\xd0\xb0\xd0\xbb\xd0\xbe\xd0'
-        '\xb2': 'Cosmic Signature',
-        '\xd0\x9a\xd0\xbe\xd1\x81\xd0\xbc\xd0\xb8\xd1\x87\xd0\xb5\xd1\x81\xd0'
-        '\xba\xd0\xb0\xd1\x8f \xd0\xb0\xd0\xbd\xd0\xbe\xd0\xbc\xd0\xb0\xd0\xbb'
-        '\xd0\xb8\xd1\x8f': 'Cosmic Anomaly',
-        '\xd0\xa0\xd0\xa3\xd0\x94\xd0\x90: \xd1\x80\xd0\xb0\xd0\xb9\xd0\xbe'
-        '\xd0\xbd \xd0\xb4\xd0\xbe\xd0\xb1\xd1\x8b\xd1\x87\xd0\xb8 \xd1\x80'
-        '\xd1\x83\xd0\xb4\xd1\x8b': 'Ore Site',
-        '\xd0\x93\xd0\x90\xd0\x97: \xd1\x80\xd0\xb0\xd0\xb9\xd0\xbe\xd0\xbd '
-        '\xd0\xb4\xd0\xbe\xd0\xb1\xd1\x8b\xd1\x87\xd0\xb8 \xd0\xb3\xd0\xb0'
-        '\xd0\xb7\xd0\xb0': 'Gas Site',
-        '\xd0\x94\xd0\x90\xd0\x9d\xd0\x9d\xd0\xab\xd0\x95: \xd1\x80\xd0\xb0'
-        '\xd0\xb9\xd0\xbe\xd0\xbd \xd1\x81\xd0\xb1\xd0\xbe\xd1\x80\xd0\xb0 '
-        '\xd0\xb4\xd0\xb0\xd0\xbd\xd0\xbd\xd1\x8b\xd1\x85': 'Data Site',
-        '\xd0\x90\xd0\xa0\xd0\xa2\xd0\x95\xd0\xa4\xd0\x90\xd0\x9a\xd0\xa2\xd0'
-        '\xab: \xd1\x80\xd0\xb0\xd0\xb9\xd0\xbe\xd0\xbd \xd0\xbf\xd0\xbe\xd0'
-        '\xb8\xd1\x81\xd0\xba\xd0\xb0 \xd0\xb0\xd1\x80\xd1\x82\xd0\xb5\xd1'
-        '\x84\xd0\xb0\xd0\xba\xd1\x82\xd0\xbe\xd0\xb2': 'Relic Site',
-        '\xd0\xa7\xd0\xb5\xd1\x80\xd0\xb2\xd0\xbe\xd1\x82\xd0\xbe\xd1\x87\xd0'
-        '\xb8\xd0\xbd\xd0\xb0': 'Wormhole',
-        '\xd0\x9e\xd0\x9f\xd0\x90\xd0\xa1\xd0\x9d\xd0\x9e: \xd1\x80\xd0\xb0'
-        '\xd0\xb9\xd0\xbe\xd0\xbd \xd0\xbf\xd0\xbe\xd0\xb2\xd1\x8b\xd1\x88'
-        '\xd0\xb5\xd0\xbd\xd0\xbd\xd0\xbe\xd0\xb9 \xd0\xbe\xd0\xbf\xd0\xb0'
-        '\xd1\x81\xd0\xbd\xd0\xbe\xd1\x81\xd1\x82\xd0\xb8': 'Combat Site',
-        # German
-        u'Kosmische Signatur': 'Cosmic Signature',
-        u'Kosmische Anomalie': 'Cosmic Anomaly',
-        u'Mineraliengebiet': 'Ore Site',
-        u'Gasgebiet': 'Gas Site',
-        u'Datengebiet': 'Data Site',
-        u'Reliktgebiet': 'Relic Site',
-        u'Wurmloch': 'Wormhole',
-        u'Kampfgebiet': 'Combat Site',
-        # Japanese
-        '\xe5\xae\x87\xe5\xae\x99\xe3\x81\xae\xe3\x82\xb7\xe3\x82\xb0\xe3\x83'
-        '\x8d\xe3\x83\x81\xe3\x83\xa3': 'Cosmic Signature',
-        '\xe5\xae\x87\xe5\xae\x99\xe3\x81\xae\xe7\x89\xb9\xe7\x95\xb0\xe7\x82'
-        '\xb9': 'Cosmic Anomaly',
-        '\xe9\x89\xb1\xe7\x9f\xb3\xe3\x82\xb5\xe3\x82\xa4\xe3\x83\x88':
-            'Ore Site',
-        '\xe3\x82\xac\xe3\x82\xb9\xe3\x82\xb5\xe3\x82\xa4\xe3\x83\x88':
-            'Gas Site',
-        '\xe3\x83\x87\xe3\x83\xbc\xe3\x82\xbf\xe3\x82\xb5\xe3\x82\xa4\xe3'
-        '\x83\x88': 'Data Site',
-        '\xe9\x81\xba\xe7\x89\xa9\xe3\x82\xb5\xe3\x82\xa4\xe3\x83\x88':
-            'Relic Site',
-        '\xe3\x83\xaf\xe3\x83\xbc\xe3\x83\xa0\xe3\x83\x9b\xe3\x83\xbc\xe3\x83'
-        '\xab': 'Wormhole',
-        '\xe6\x88\xa6\xe9\x97\x98\xe3\x82\xb5\xe3\x82\xa4\xe3\x83\x88':
-            'Combat Site',
-    }
-    try:
-        text = TRANSLATE_DICT[client_text]
-        return text
-    except KeyError:
-        return None
-
-
-def _update_sig_from_tsv(signature, row):
-    COL_SIG = 0
-    COL_SIG_TYPE = 3
-    COL_SIG_GROUP = 2
-    COL_SIG_SCAN_GROUP = 1
-    COL_SIG_STRENGTH = 4
-    COL_DISTANCE = 5
-    info = row[COL_SIG_TYPE]
-    updated = False
-    sig_type = None
-    debug_text = row[COL_SIG_SCAN_GROUP]
-    scan_group = _translate_client_string(row[COL_SIG_SCAN_GROUP])
-    if scan_group == "Cosmic Signature" or scan_group == "Cosmic Anomaly":
-        try:
-            sig_type_name = _translate_client_string(row[COL_SIG_GROUP])
-            sig_type = SignatureType.objects.get(longname=sig_type_name)
-        except:
-            sig_type = None
-    else:
-        sig_type = None
-
-    if sig_type:
-        updated = True
-
-    if sig_type:
-        signature.sigtype = sig_type
-    signature.updated = updated or signature.updated
-    if info:
-        signature.info = info
-    if signature.info is None:
-        signature.info = ''
-
-    return signature
-
-
 # noinspection PyUnusedLocal
 @login_required
 @require_map_permission(permission=2)
@@ -638,8 +533,11 @@ def bulk_sig_import(request, map_id, ms_id):
     """
     if not request.is_ajax():
         raise PermissionDenied
+    
     map_system = get_object_or_404(MapSystem, pk=ms_id)
-    k = 0
+    k = 0 # all imported sigs
+    numchanged = 0 # sigs changed during import 
+    numscanned = 0 # sigs changed and fully scanned down during import
     if request.method == 'POST':
         reader = csv.reader(
             request.POST.get('paste', '').decode().splitlines(),
@@ -654,26 +552,39 @@ def bulk_sig_import(request, map_id, ms_id):
             except IndexError:
                 return HttpResponse('A valid signature paste was not found',
                                     status=400)
+            # limit number of rows pasted
             if k < 75:
+                # get sig id from pasted data
                 sig_id = utils.convert_signature_id(row[COL_SIG])
-                sig = Signature.objects.get_or_create(
-                    sigid=sig_id, system=map_system.system)[0]
-                sig = _update_sig_from_tsv(sig, row)
+                # Query signatures in system to see if it exists
+                sig, sigcreated = Signature.objects.get_or_create(
+                    sigid=sig_id, system=map_system.system)
+
+                # Update sig with copied TSV data
+                sig, update_type = sig.update_from_tsv(request.user, sigcreated, row, map_system)
+                
                 sig.modified_by = request.user
                 sig.save()
                 signals.signature_update.send_robust(
                     sig, user=request.user, map=map_system.map,
                     signal_strength=row[COL_STRENGTH]
                 )
-
+                # increment really changed sigs counter
+                if update_type == "Updated" or update_type == "Created":
+                    numchanged += 1
+                if update_type == "Scanned":
+                    numscanned += 1
+                # increment all imported sigs counter
                 k += 1
 
+        # Log the summary as a publicly visible log entry
         map_system.map.add_log(
             request.user,
-            "Imported %s signatures for %s(%s)." %
-            (k, map_system.system.name, map_system.friendlyname),
-            True
-        )
+            "Imported %s signatures for %s(%s). Adjusted:  %s. Scanned: %s." %
+            (k, map_system.system.name, map_system.friendlyname, numchanged, 
+             numscanned),
+            True)
+        
         map_system.system.lastscanned = datetime.now(pytz.utc)
         map_system.system.save()
         return HttpResponse()
@@ -708,42 +619,55 @@ def edit_signature(request, map_id, ms_id, sig_id=None):
     if map_system.map.get_permission(request.user) != 2:
         return HttpResponse()
     action = None
+    isnewscan = False
+
     if sig_id is not None:
         signature = get_object_or_404(Signature, pk=sig_id)
         created = False
         if not signature.owned_by:
             signature.toggle_ownership(request.user)
+
     if request.method == 'POST':
         form = SignatureForm(request.POST)
         if form.is_valid():
+            # get data from form
             ingame_id = utils.convert_signature_id(form.cleaned_data['sigid'])
-            if sig_id is None:
-                signature, created = Signature.objects.get_or_create(
-                    system=map_system.system, sigid=ingame_id)
-
-            signature.sigid = ingame_id
-            signature.updated = True
-            signature.info = form.cleaned_data['info']
+            ingame_info = form.cleaned_data['info']
             if request.POST['sigtype'] != '':
                 sigtype = form.cleaned_data['sigtype']
             else:
                 sigtype = None
+
+            # If new sig entered manually, create it
+            if sig_id is None:
+                signature, created = Signature.objects.get_or_create(
+                    system=map_system.system, sigid=ingame_id)
+            # Check for new scan info
+            if ingame_info != '' and signature.info != ingame_info:
+                isnewscan = True
+            # Populate signature
+            signature.sigid = ingame_id
+            signature.info = ingame_info
             signature.sigtype = sigtype
+            # Update signature
             signature.modified_by = request.user
-            signature.save()
+            signature.update()
+            
             map_system.system.lastscanned = datetime.now(pytz.utc)
             map_system.system.save()
+
+            # log the update
             if created:
                 action = 'Created'
+            if isnewscan:
+                action = 'Scanned'
             else:
                 action = 'Updated'
+            signature.log_sig(request.user, action, map_system)
+            
             if signature.owned_by:
                 signature.toggle_ownership(request.user)
-            map_system.map.add_log(request.user,
-                                   "%s signature %s in %s (%s)" %
-                                   (action, signature.sigid,
-                                    map_system.system.name,
-                                    map_system.friendlyname))
+
             signals.signature_update.send_robust(signature, user=request.user,
                                                  map=map_system.map)
         else:
@@ -833,10 +757,8 @@ def delete_signature(request, map_id, ms_id, sig_id):
         raise PermissionDenied
     map_system = get_object_or_404(MapSystem, pk=ms_id)
     sig = get_object_or_404(Signature, pk=sig_id)
-    sig.delete()
-    map_system.map.add_log(request.user, "Deleted signature %s in %s (%s)." %
-                           (sig.sigid, map_system.system.name,
-                            map_system.friendlyname))
+    sig.delete(request.user, map_system)
+
     return HttpResponse()
 
 
@@ -1386,7 +1308,9 @@ def purge_signatures(request, map_id, ms_id):
         raise PermissionDenied
     mapsys = get_object_or_404(MapSystem, pk=ms_id)
     if request.method == "POST":
-        mapsys.system.signatures.all().delete()
+        siglist = mapsys.system.signatures.all()
+        for sig in siglist:
+            sig.delete(request.user, mapsys)
         return HttpResponse()
     else:
         return HttpResponse(status=400)

--- a/evewspace/POS/models.py
+++ b/evewspace/POS/models.py
@@ -21,7 +21,7 @@ import eveapi
 from core.models import Type, Location
 from API.models import CorpAPIKey
 from core.models import Corporation, Alliance
-from Map.models import System
+from Map.models import System, MapSystem, Map
 from API import cache_handler as handler
 
 
@@ -128,6 +128,16 @@ class POS(models.Model):
         import pytz
         self.updated = datetime.now(pytz.utc)
         super(POS, self).save(*args, **kwargs)
+
+    def log(self, user, action, map_system):
+        """
+        Records a log entry for POS updates and additions.
+        """
+        map_system.map.add_log(
+            user, 
+            "%s POS (Planet %s Moon %s, owner %s) in %s (%s), %s jumps out from root system."
+            %(action, self.planet, self.moon, self.corporation, map_system.system.name, 
+              map_system.friendlyname, map_system.distance_from_root()))
 
     def size(self):
         """

--- a/evewspace/POS/templates/add_pos.html
+++ b/evewspace/POS/templates/add_pos.html
@@ -59,10 +59,10 @@
     }
     $('#addPOSForm').submit(function(e){
                 e.preventDefault();
-                AddPOS({{system.pk}});
+                AddPOS({{mapsystem.pk}},{{mapsystem.system.pk}});
                 });
     $('#btnAddPOS').click(function(e){
-                AddPOS({{system.pk}});
+                AddPOS({{mapsystem.pk}},{{mapsystem.system.pk}});
                 });
     $('#auto').click(function(e){
         $('.manual-fields, #manual-help').hide();

--- a/evewspace/POS/templates/edit_pos.html
+++ b/evewspace/POS/templates/edit_pos.html
@@ -14,7 +14,7 @@
          <div class="alert alert-error" id="pos_message" style="display: none;">
             <p id="pos_error"></p>
          </div>
-   <form id="editPOSForm" action="/pos/{{system.pk}}/{{pos.id}}/edit/" method="POST">
+   <form id="editPOSForm" action="/pos/{{mapsystem.pk}}/{{pos.id}}/edit/" method="POST">
         {% csrf_token %}
         Full Corp Name: <input id="corpBox" class="corpAuto" value="{{pos.corporation.name}}" name="corp" type="text" > <br />
         <span class="label label-warning" id="digiterror">Please enter digits only for planet and moon. </span><br /><br />
@@ -48,12 +48,12 @@
     }
     $('#editPOSForm').submit(function(e){
                 e.preventDefault();
-                EditPOS({{pos.pk}}, {{system.pk}});
+                EditPOS({{pos.pk}}, {{mapsystem.pk}});
                 $('#modalHolder').modal('hide');
                 return false;
                 });
     $('#btnEditPOS').click(function(e){
-                EditPOS({{pos.pk}}, {{system.pk}});
+                EditPOS({{pos.pk}}, {{mapsystem.pk}});
                 $('#modalHolder').modal('hide');
                 });
     </script>

--- a/evewspace/POS/templates/posdetails_small.html
+++ b/evewspace/POS/templates/posdetails_small.html
@@ -1,9 +1,9 @@
 <li id="pos{{pos.pk}}" class="posListItem">
 {% if perms.POS.change_pos %}
-<i class="icon-pencil" onclick="GetEditPOSDialog({{pos.pk}}, {{system.pk}});" title="Edit POS"></i>
+<i class="icon-pencil" onclick="GetEditPOSDialog({{pos.pk}}, {{mapsystem.pk}});" title="Edit POS"></i>
 {% endif %}
 {% if perms.POS.delete_pos %}
-<i class="icon-ban-circle" onclick="DeletePOS({{pos.pk}}, {{system.pk}});" title="Delete POS"></i>
+<i class="icon-ban-circle" onclick="DeletePOS({{pos.pk}}, {{mapsystem.pk}});" title="Delete POS"></i>
 {% endif %}
 
 <div class="poslist_header" data-toggle="collapse" data-target="#pos{{pos.pk}}Details" style="position:relative">

--- a/evewspace/POS/templates/poslist.html
+++ b/evewspace/POS/templates/poslist.html
@@ -2,7 +2,7 @@
 <div id="sys{{system.pk}}POSDiv">
 <ul>
     {% for p in poses %}
-        {% posdetails system p %}
+        {% posdetails mapsystem p %}
         <br />
     {% empty %}
         <li>No Starbases!</li>

--- a/evewspace/POS/templatetags/poslist.py
+++ b/evewspace/POS/templatetags/poslist.py
@@ -13,17 +13,20 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 from django import template
+from django.shortcuts import get_object_or_404
 from POS.models import POS
+from Map.models import System, MapSystem
 
 register=template.Library()
 
-
 @register.inclusion_tag('poslist.html', takes_context=True)
-def poslist(context, system):
-    poses = POS.objects.filter(system=system)
-    return {'poses': poses, 'system': system, 'request': context['request']}
+def poslist(context, mapsystem):
+	mapsystem = get_object_or_404(MapSystem, pk=mapsystem)
+	system = get_object_or_404(System, pk=mapsystem.system.pk)
+	poses = POS.objects.filter(system=system)
+	return {'poses': poses, 'mapsystem': mapsystem, 'request': context['request']}
 
 
 @register.inclusion_tag('posdetails_small.html', takes_context=True)
-def posdetails(context, system, pos):
-    return {'pos' : pos, 'system': system, 'perms': context['perms']}
+def posdetails(context, mapsystem, pos):
+	return {'pos' : pos, 'mapsystem': mapsystem, 'perms': context['perms']}

--- a/evewspace/POS/templatetags/poslist.py
+++ b/evewspace/POS/templatetags/poslist.py
@@ -21,12 +21,12 @@ register=template.Library()
 
 @register.inclusion_tag('poslist.html', takes_context=True)
 def poslist(context, mapsystem):
-	mapsystem = get_object_or_404(MapSystem, pk=mapsystem)
-	system = get_object_or_404(System, pk=mapsystem.system.pk)
-	poses = POS.objects.filter(system=system)
-	return {'poses': poses, 'mapsystem': mapsystem, 'request': context['request']}
+    mapsystem = get_object_or_404(MapSystem, pk=mapsystem)
+    system = get_object_or_404(System, pk=mapsystem.system.pk)
+    poses = POS.objects.filter(system=system)
+    return {'poses': poses, 'mapsystem': mapsystem, 'request': context['request']}
 
 
 @register.inclusion_tag('posdetails_small.html', takes_context=True)
 def posdetails(context, mapsystem, pos):
-	return {'pos' : pos, 'mapsystem': mapsystem, 'perms': context['perms']}
+    return {'pos' : pos, 'mapsystem': mapsystem, 'perms': context['perms']}

--- a/evewspace/POS/urls.py
+++ b/evewspace/POS/urls.py
@@ -15,16 +15,17 @@
 from django.conf.urls import patterns, include, url
 
 pospatterns = patterns('POS.views',
-        url(r'remove/$', 'remove_pos'),
-        url(r'edit/$', 'edit_pos'),
-        )
+    	url(r'remove/$', 'remove_pos'),
+    	url(r'edit/$', 'edit_pos'),
+    	)
 
 syspatterns = patterns('POS.views',
-        url(r'(?P<posID>\d+)/', include(pospatterns)),
-        url(r'add/$', 'add_pos'),
-        url(r'$', 'get_pos_list'),
-        )
+		url(r'(?P<posID>\d+)/', include(pospatterns)),
+		url(r'add/$', 'add_pos'),
+		url(r'$', 'get_pos_list'),
+		)
 
 urlpatterns = patterns('POS.views',
-        url(r'(?P<sysID>\d+)/', include(syspatterns)),
-        )
+		url(r'(?P<msID>\d+)/', include(syspatterns)),
+		)
+


### PR DESCRIPTION
Added Signature and POS logging functionality on request of my Eve University corpmates. Signature create/edit/bulk import now results in log entries per signature, and I tried to differentiate between real edits (with meaningful changes/complete scans) and simple "click edit and submit" action. Also includes distance from root system in the logging.
For POSes it does a similar thing, this required some changes in the URLs - now passing mapsystem ID along instead of system (logging requires the active map to be known).