### PR TITLE
Docker container for eve-wspace on ubuntu and mysql.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,97 @@
+# EVE WSPACE MYSQL
+#
+# VERSION               0.2
+
+FROM ubuntu:12.04
+MAINTAINER Papazafeiropoulos Giorgos <g.papazafeiropoulos@gmail.com>
+
+# Exposed ENV
+#Modify them to depict your instalation environment
+#NGINX server name
+ENV NGINX_HOSTNAME rens
+#MYSQL user and password for the application
+ENV MYSQL_USER maptool
+ENV MYSQL_PASS maptool123
+#DJANGO unique key - create a new one!
+ENV DJANGO_KEY @o3zk1@4^d3osu-om9-_=(hvr48o*%c+@h3d$%pg2g+ta2g2v(
+
+
+# DO NOT MODIFY THESE!
+# avoid debconf and initrd
+ENV DEBIAN_FRONTEND noninteractive
+ENV INITRD No
+
+
+#Update packages and install needed.
+RUN apt-get -y update
+RUN apt-get install -y git-core build-essential python-dev python-pip nginx bzip2 memcached libmysqlclient-dev mysql-server libxml2-dev libxslt-dev rabbitmq-server supervisor curl sudo libyaml-dev vim
+RUN	sed	-i -e "s/^bind-address\s*=\s*127.0.0.1/bind-address	=	0.0.0.0/"	/etc/mysql/my.cnf
+
+#Set up nginx as daemon off.
+RUN sed -i -e '1idaemon off;' /etc/nginx/nginx.conf
+
+RUN easy_install -U distribute 
+RUN pip install virtualenv
+
+#Set up the mysql db.
+ADD mysql_setup.sh /mysql_setup.sh
+RUN chmod +x /mysql_setup.sh
+RUN /mysql_setup.sh
+
+# set root password
+RUN echo "root:root" | chpasswd
+
+# copy supervisor conf
+ADD supervisor/conf.d /etc/supervisor/conf.d
+
+ADD evewspace.sh evewspace.sh
+RUN chmod +x evewspace.sh
+
+#Set Maptool user
+RUN adduser --disabled-password --gecos '' ${MYSQL_USER} && adduser ${MYSQL_USER} sudo && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER ${MYSQL_USER}
+WORKDIR /home/${MYSQL_USER}
+RUN mkdir /home/${MYSQL_USER}/static
+
+#Get eve-wspace code
+RUN git clone https://github.com/marbindrakon/eve-wspace.git
+
+
+#Install the eve dumb data
+RUN curl -O https://www.fuzzwork.co.uk/dump/mysql-latest.tar.bz2
+RUN mkdir evedumb && tar xvf mysql-latest.tar.bz2 -C evedumb
+
+RUN sudo /usr/sbin/mysqld &\
+	sleep 10s &&\
+	sudo find ./evedumb -type f -name "*.sql" -exec sh -c "mysql -u ${MYSQL_USER} -p${MYSQL_PASS} evewspace < {}" \;
+
+RUN rm -rf evedumb
+RUN rm -rf mysql-latest.tar.bz2
+
+#Install Eve-Wspace Environment
+#Add evewspace configuration tool and make it accessible
+RUN sudo /usr/sbin/mysqld &\
+	sleep 10s &&\ 
+	/evewspace.sh
+
+#Get back to root
+USER root
+
+#Set up nginx
+ADD nginx/evewspace /etc/nginx/sites-available/evewspace
+RUN sed -i -e "s/server_name name;/server_name ${NGINX_HOSTNAME};/"	/etc/nginx/sites-available/evewspace
+RUN sed -i -e "s/{MYSQL_USER}/${MYSQL_USER}/" /etc/nginx/sites-available/evewspace
+RUN rm /etc/nginx/sites-enabled/default
+RUN ln -s /etc/nginx/sites-available/evewspace /etc/nginx/sites-enabled/evewspace
+
+#Set up celery and gunicorn
+RUN sed -i -e "s/{MYSQL_USER}/${MYSQL_USER}/g" /etc/supervisor/conf.d/celery.conf
+RUN sed -i -e "s/{MYSQL_USER}/${MYSQL_USER}/g" /etc/supervisor/conf.d/gunicorn.conf
+# clean packages
+RUN apt-get clean
+RUN rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+# start supervisor
+EXPOSE 80
+CMD ["/usr/bin/supervisord"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,79 @@
+Docker Set Up
+=============
+
+What is it?
+-----------
+A docker container that can be used to quickly provision a functional eve-wspace application stack.
+Will pull latest code from github, latest packages for dependencies for Ubuntu 12.04 LTS, and latest 
+evedumb database and create an image with all these installed and configured to run the eve-wspace application.
+Will set it up to use mysql db and nginx as described in the documentation for installing the application.
+Supervisor is used to make sure everything is started and run as expected.
+
+Documentation
+-------------
+
+Prerequisites
+-------------
+A running installation of Docker is required. Version used is 1.5.0, so use that or later.
+Basic knowledge of Docker commands and how all work will be beneficial.
+
+Create the image
+----------------
+Docker containers are based on an image. We will create an image that will have the eve-wspace 
+ready servicing users. Thus all configurations shall be done at this step. This will allow faster 
+start up times since we won't have to initialize db's ect. 
+
+Clone/Download the project and cd into the docker directory. The Dockerfile must be in your current directory.
+Open it with a text editor and edit the environment variables at the top of the file, to your liking.
+
+Create the image named gpapaz/eve-wspace-mysql.
+
+	$ sudo docker build -t "gpapaz/eve-wspace-mysql" .
+
+Wait till you see the end of the process ... and a success message!
+You can check that the image was build with:
+
+	$ sudo docker images | grep "gpapaz/eve-wspace-mysql"
+
+If you want to remove the created image - thus not been able to start new evewspace containers -
+just type:
+
+	$ sudo docker rmi "gpapaz/eve-wspace-mysql"
+
+Start a container
+-----------------
+Now that we have an image for our container we can start one or even more!
+
+	$ sudo docker run -d -p 8080:80 --name evewspace gpapaz/eve-wspace-mysql
+
+A new container named evewspace will be created, will be set to run as daemon, will 
+redirect its internal 80 tcp port to our localhost's 8080 tcp port, and of course will 
+be based to our eve-wspace image. When it is started the container will also start all the 
+needed servers for the eve-wspace to operate as expected!
+
+That's it! Your eve-wspace application is up and running and can be accessed from your PC through a 
+web browser. Just point to 
+
+	http::/<your_pc_ip>:8080 
+
+or wherever your nginx server was configured during the image 
+creation.
+
+If you wish to stop the container:
+
+	$ sudo docker stop evewspace
+
+And to restart it:
+
+	$ sudo docker start evewspace	
+
+To access it while running:
+
+	$ sudo docker exec -it evewspace /bin/bash
+
+Use CTR-D or exit to return to your localhost.
+
+And finally if you want to remove the container (stop it before):
+
+	$ sudo docker rm evewspace
+

--- a/docker/evewspace.sh
+++ b/docker/evewspace.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+virtualenv --no-site-packages /home/maptool/eve-wspace 
+source /home/maptool/eve-wspace/bin/activate 
+pip install -r /home/maptool/eve-wspace/requirements-mysql.txt 
+
+cd /home/maptool/eve-wspace/evewspace/evewspace 
+cp local_settings.py.example local_settings.py 
+sed -i -e "s/'alan_please_add_secret_key'/'${DJANGO_KEY}'/" local_settings.py
+sed -i -e "s/'django.db.backends.'/'django.db.backends.mysql'/" local_settings.py 
+sed -i -e "s/'root'/'${MYSQL_USER}'/" local_settings.py 
+sed -i -e "s/'PASSWORD': ''/'PASSWORD': '${MYSQL_PASS}'/" local_settings.py 
+sed -i -e "s/DEBUG = True/DEBUG = False/" local_settings.py
+
+cd /home/maptool/eve-wspace/evewspace 
+echo "./manage.py syncdb --all --noinput"
+./manage.py syncdb --all --noinput 
+echo "./manage.py migrate --fake"
+./manage.py migrate --fake 
+echo "./manage.py buildsystemdata"
+./manage.py buildsystemdata 
+echo "./manage.py loaddata */fixtures/*.json"
+./manage.py loaddata */fixtures/*.json 
+echo "./manage.py defaultsettings"
+./manage.py defaultsettings 
+echo "./manage.py resetadmin"
+./manage.py resetadmin 
+echo "./manage.py syncrss"
+./manage.py syncrss 
+echo "./manage.py collectstatic --noinput"
+./manage.py collectstatic --noinput 
+
+echo "Install gunicorn"
+pip install gunicorn
+
+

--- a/docker/mysql.sql
+++ b/docker/mysql.sql
@@ -1,0 +1,4 @@
+/usr/sbin/mysqld &
+sleep 10
+echo "CREATE DATABASE evewspace CHARACTER SET utf8;" | mysql
+echo "GRANT ALL PRIVILEGES ON evewspace.* TO '${MYSQL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_USER}';" | mysql

--- a/docker/mysql_setup.sh
+++ b/docker/mysql_setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+/usr/sbin/mysqld &
+sleep 10
+echo "CREATE DATABASE evewspace CHARACTER SET utf8;" | mysql
+echo "GRANT ALL PRIVILEGES ON evewspace.* TO '${MYSQL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PASS}';" | mysql

--- a/docker/nginx/evewspace
+++ b/docker/nginx/evewspace
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name name;
+    underscores_in_headers on;
+
+    location /static {
+        alias /home/{MYSQL_USER}/static;
+    }
+
+    location / {
+        proxy_pass_header Server;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_connect_timeout 10;
+        proxy_read_timeout 30;
+        proxy_pass http://127.0.0.1:8000;
+    }
+}

--- a/docker/supervisor/conf.d/celery.conf
+++ b/docker/supervisor/conf.d/celery.conf
@@ -1,0 +1,9 @@
+[program:celeryd]
+command=python manage.py celery worker -B --loglevel=info
+directory=/home/{MYSQL_USER}/eve-wspace/evewspace
+environment=PATH=/home/{MYSQL_USER}/eve-wspace/bin
+user={MYSQL_USER}
+autostart=true
+autorestart=true
+redirect_stderr=True
+

--- a/docker/supervisor/conf.d/gunicorn.conf
+++ b/docker/supervisor/conf.d/gunicorn.conf
@@ -1,0 +1,9 @@
+[program:gunicorn]
+command=/home/{MYSQL_USER}/eve-wspace/bin/gunicorn_django --workers=4 -b 127.0.0.1:8000 /home/{MYSQL_USER}/eve-wspace/evewspace/evewspace/settings.py
+directory=/home/{MYSQL_USER}/eve-wspace/evewspace/evewspace
+environment=PATH=/home/{MYSQL_USER}/eve-wspace/bin
+user={MYSQL_USER}
+autostart=true
+autorestart=true
+redirect_stderr=True
+

--- a/docker/supervisor/conf.d/mysql.conf
+++ b/docker/supervisor/conf.d/mysql.conf
@@ -1,0 +1,3 @@
+[program:mysql]
+command=/usr/bin/pidproxy /var/run/mysqld/mysqld.pid /usr/sbin/mysqld
+autorestart=true

--- a/docker/supervisor/conf.d/nginx.conf
+++ b/docker/supervisor/conf.d/nginx.conf
@@ -1,0 +1,5 @@
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_events_enabled=true
+stderr_events_enabled=true
+autostart=true

--- a/docker/supervisor/conf.d/rabbitmq.conf
+++ b/docker/supervisor/conf.d/rabbitmq.conf
@@ -1,0 +1,6 @@
+[program:rabbitmq]
+command=/usr/sbin/rabbitmq-server
+numprocs=1
+autostart=true
+autorestart=true
+

--- a/docker/supervisor/conf.d/supervisord.conf
+++ b/docker/supervisor/conf.d/supervisord.conf
@@ -1,0 +1,6 @@
+[supervisord]
+nodaemon=true
+
+
+
+


### PR DESCRIPTION
Documentation describes all needed to create the docker container and start it. Can be used to automate the deployment of evewspace - will require some extra tuning of course - or as an alternative to vagrant for development.